### PR TITLE
Fix links to source in docs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -16,7 +16,7 @@ makedocs(
         "Citations" => "citations.md",
         "Contribute" => "contributing.md",
     ],
-    repo = "github.com/chrishalcrow/Skyrmions3D.jl",
+    repo = Documenter.Remotes.GitHub("chrishalcrow", "Skyrmions3D.jl"),
 )
 
 deploydocs(;


### PR DESCRIPTION
This changes the value of the repo kwarg from a hardcoded string to a Documenter.jl Remote object.

This fixes a regression (see #6) introduced in #20, which broke links to the program source on the [API page](https://chrishalcrow.github.io/Skyrmions3D.jl/dev/api/) of the documentation.

The regression was reproduced locally and this change fixes it locally.
As this is a documentation issue we cannot mark #6 fixed until we verify that this change fixes the issue on CI.


