### PR TITLE
Add symmetry tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+- repo: https://github.com/qiaojunfeng/pre-commit-julia-format
+  rev: v0.2.0                # use the most recent version
+  hooks:
+  - id: julia-format         # formatter for Julia code

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -17,8 +17,7 @@ makedocs(
         "Contribute" => "contributing.md",
     ],
     repo = Documenter.Remotes.GitHub("chrishalcrow", "Skyrmions3D.jl"),
+    checkdocs=:exports,
 )
 
-deploydocs(;
-           repo = "github.com/chrishalcrow/Skyrmions3D.jl",
-           )
+deploydocs(; repo = "github.com/chrishalcrow/Skyrmions3D.jl")

--- a/src/properties.jl
+++ b/src/properties.jl
@@ -361,7 +361,7 @@ Compute a variety of currents in the Skyrme model, based on a `skyrmion`.
 
 You can calculate specific indices using e.g. `indices = [1,2]`. If `indices = [0,0]`, the function will calculate all indices. If `density = false`, the function will return the integrated densities, while `density = true` it will return the densities. 
 
-The possible currents are (currently):
+The possible currents are:
 - `uMOI`: the isospin moment of inertia.
 - `wMOI`: the mixed moment of inertia.
 - `vMOI`: the spin moment of inertia.
@@ -412,7 +412,7 @@ function compute_current(sk; label = "NULL", indices = [0, 0], density = false, 
 
             if label == "uMOI"
 
-                Tiam, Lia = getTiam(p), getLka(p, dp)
+                Tiam, Lia = getTiam(p), getLia(p, dp)
 
                 for a in aindices, b in bindices
                     current_density[a, b, i, j, k] = -trace_su2_ij(Tiam, Tiam, a, b)*rm
@@ -424,7 +424,7 @@ function compute_current(sk; label = "NULL", indices = [0, 0], density = false, 
 
             elseif label == "wMOI"
 
-                Tiam, Lia = getTiam(p), getLka(p, dp)
+                Tiam, Lia = getTiam(p), getLia(p, dp)
                 Gia = -1.0 .* getGia(Lia, xxx)
 
                 for a in aindices, b in bindices
@@ -437,7 +437,7 @@ function compute_current(sk; label = "NULL", indices = [0, 0], density = false, 
 
             elseif label == "vMOI"
 
-                Lia = getLka(p, dp)
+                Lia = getLia(p, dp)
                 Gia = -1.0 .* getGia(Lia, xxx)
 
                 for a in aindices, b in bindices
@@ -450,7 +450,7 @@ function compute_current(sk; label = "NULL", indices = [0, 0], density = false, 
 
             elseif label == "uAxial"
 
-                Tiam, Tiap, Lia = getTiam(p), getTiap(p), getRka(p, dp)
+                Tiam, Tiap, Lia = getTiam(p), getTiap(p), getRia(p, dp)
 
                 for a in aindices, b in bindices
                     current_density[a, b, i, j, k] = -trace_su2_ij(Tiam, Tiap, a, b)*rm
@@ -462,7 +462,7 @@ function compute_current(sk; label = "NULL", indices = [0, 0], density = false, 
 
             elseif label == "wAxial"
 
-                Tiap, Lia = getTiap(p), getLka(p, dp)
+                Tiap, Lia = getTiap(p), getLia(p, dp)
                 Gia = -1.0 .* getGia(Lia, xxx)
 
                 for a in aindices, b in bindices
@@ -476,7 +476,7 @@ function compute_current(sk; label = "NULL", indices = [0, 0], density = false, 
 
             elseif label == "stress"
 
-                Lia = getLka(p, dp)
+                Lia = getLia(p, dp)
 
                 for a in aindices, b in bindices
 
@@ -506,7 +506,7 @@ function compute_current(sk; label = "NULL", indices = [0, 0], density = false, 
 
             elseif label == "NoetherIso"
 
-                Lia, Tiam = getLka(p, dp), getTiam(p)
+                Lia, Tiam = getLia(p, dp), getTiam(p)
 
                 for a in aindices, b in bindices
 
@@ -520,7 +520,7 @@ function compute_current(sk; label = "NULL", indices = [0, 0], density = false, 
                 end
             elseif label == "NoetherAxial"
 
-                Lia, Tiap = getLka(p, dp), getTiap(p)
+                Lia, Tiap = getLia(p, dp), getTiap(p)
 
                 for a in aindices, b in bindices
 
@@ -567,7 +567,12 @@ function compute_current(sk; label = "NULL", indices = [0, 0], density = false, 
 
 end
 
-
+"""
+Compute G_ia where
+G_i = levicivita_{ilm} x_l L_ma for i=1,2,3
+G_i = 1/2 U^{-1} [tau_i, U]     for i=4,5,6
+tau are the Pauli spin matrices
+"""
 function getGia(Lia, x)
 
     return SMatrix{3,3,Float64,9}(
@@ -584,6 +589,11 @@ function getGia(Lia, x)
 
 end
 
+"""
+Compute Tm_{a} = i/2*U^{-1}[tau_a, U] from the pion field p.
+tau are the Pauli spin matrices
+a denotes the component of the pion field
+"""
 function getTiam(p)
 
     return SMatrix{3,3,Float64,9}(
@@ -600,6 +610,11 @@ function getTiam(p)
 
 end
 
+"""
+Compute Tp_{a} = i/2[tau_a, U]U^{-1} from the pion field p.
+tau are the Pauli spin matrices
+a denotes the component of the pion field
+"""
 function getTiap(p)
 
     return SMatrix{3,3,Float64,9}(
@@ -616,7 +631,12 @@ function getTiap(p)
 
 end
 
-function getRka(p, dp)
+"""
+Compute R_{ia} = ((d_i U)U^{-1})_a from the pion field p and its derivative dp.
+d_i denotes the spatial derivative
+a denotes the component of the pion field
+"""
+function getRia(p, dp)
 
     return SMatrix{3,3,Float64,9}(
         -(dp[1, 4]*p[1]) - dp[1, 3]*p[2] + dp[1, 2]*p[3] + dp[1, 1]*p[4],
@@ -632,7 +652,12 @@ function getRka(p, dp)
 
 end
 
-function getLka(p, dp)
+"""
+Compute L_{ia} = (U^{-1}(d_i U))_a from the pion field p and its derivative dp.
+d_i denotes the spatial derivative
+a denotes the component of the pion field
+"""
+function getLia(p, dp)
 
     return SMatrix{3,3,Float64,9}(
         -(dp[1, 4]*p[1]) + dp[1, 3]*p[2] - dp[1, 2]*p[3] + dp[1, 1]*p[4],
@@ -648,10 +673,16 @@ function getLka(p, dp)
 
 end
 
-function trace_su2_ij(Lia, Lib, i, j)
-    return -2.0*(Lia[1, i]*Lib[1, j] + Lia[2, i]*Lib[2, j] + Lia[3, i]*Lib[3, j])
+"""
+Returns the evaluation of Tr(L1_{i}L2_{j})
+"""
+function trace_su2_ij(L1, L2, i, j)
+    return -2.0*(L1[i, 1]*L2[j, 1] + L1[i, 2]*L2[j, 2] + L1[i, 3]*L2[j, 3])
 end
 
+"""
+Returns the evaluation of Tr([L1_i,L2_j][L1_k,L2_l])
+"""
 function trace_su2_ijkl(L1, L2, L3, L4, i, j, k, l)
     return -8.0*(
         L1[

--- a/test/do_symmetry_tests.jl
+++ b/test/do_symmetry_tests.jl
@@ -1,0 +1,102 @@
+# Set of tests to check numerical results against known analytic results
+# Always do this with a pion mass - a more stringent test than massless
+# Good resources for these tests: https://arxiv.org/pdf/0707.0868
+
+using Skyrmions3D
+
+spherically_symmetric_skyrmion = Skyrmion(10,0.2, mpi=1.0)
+p1(z) = z
+q1(z) = 1
+f1(r) = pi*exp( -(r.^3)./12.0 )
+make_rational_map!(spherically_symmetric_skyrmion, p1, q1, f1)
+
+U1 = compute_current(spherically_symmetric_skyrmion, label="uMOI")
+V1 = compute_current(spherically_symmetric_skyrmion, label="vMOI")
+W1 = compute_current(spherically_symmetric_skyrmion, label="wMOI")
+
+tol = 1e-10
+
+@test isapprox(U1[1,1],U1[2,2], atol=tol)
+@test isapprox(U1[2,2],U1[3,3], atol=tol)
+
+@test isapprox(W1[1,1],W1[2,2], atol=tol)
+@test isapprox(W1[2,2],W1[3,3], atol=tol)
+
+@test isapprox(V1[1,1],V1[2,2], atol=tol)
+@test isapprox(V1[2,2],V1[3,3], atol=tol)
+
+for a in 1:3, b in 1:3
+    if a != b
+        @test isapprox(U1[a,b], 0, atol=tol)
+        @test isapprox(W1[a,b], 0, atol=tol)
+        @test isapprox(V1[a,b], 0, atol=tol)
+    end
+end
+
+cubic_skyrmion = Skyrmion(10,0.4, mpi=1.0)
+p4(z) = z^4 + 2.0*sqrt(3.0)*im*z^2 + 1.0;
+q4(z) = z^4 - 2.0*sqrt(3.0)*im*z^2 + 1.0;
+f4(r) = pi*exp( -(r.^3)./12.0 )
+
+make_rational_map!(cubic_skyrmion, p4, q4, f4)
+
+U4 = compute_current(cubic_skyrmion, label="uMOI")
+V4 = compute_current(cubic_skyrmion, label="vMOI")
+W4 = compute_current(cubic_skyrmion, label="wMOI")
+
+tol = 1e-7
+
+@test isapprox(U4[1,1],U4[2,2], atol=tol)
+
+@test isapprox(V4[1,1],V4[2,2], atol=tol)
+@test isapprox(V4[2,2],V4[3,3], atol=tol)
+
+for a in 1:3, b in 1:3
+    if a != b
+        @test isapprox(U4[a,b], 0, atol=tol)
+        @test isapprox(V4[a,b], 0, atol=tol)
+    end
+    @test isapprox(W4[a,b], 0, atol=tol)
+end
+
+# tetrahedral ADHM skyrmion
+
+using Quaternions
+
+tetrahedral_skyrmion = Skyrmion(10,0.4, mpi=1.0)
+
+B=3
+
+adhm_data = [Quaternion(0.0, 0.0, 0.0, 0.0) for a = 1:(B+1), b = 1:B]
+
+lam = 1.0
+
+adhm_data[1, 1] = Quaternion(lam, 0.0, 0.0, 0.0)
+adhm_data[1, 2] = Quaternion(0.0, lam, 0.0, 0.0)
+adhm_data[1, 3] = Quaternion(0.0, 0.0, lam, 0.0)
+
+adhm_data[2, 2] = Quaternion(0.0, 0.0, lam, 0.0)
+adhm_data[2, 3] = Quaternion(0.0, lam, 0.0, 0.0)
+
+adhm_data[3, 1] = Quaternion(0.0, 0.0, lam, 0.0)
+adhm_data[3, 3] = Quaternion(lam, 0.0, 0.0, 0.0)
+
+adhm_data[4, 1] = Quaternion(0.0, lam, 0.0, 0.0)
+adhm_data[4, 2] = Quaternion(lam, 0.0, 0.0, 0.0)
+
+# The make_ADHM! function is similar to the make_rational_map! function:
+
+make_ADHM!(tetrahedral_skyrmion, adhm_data)
+
+U3 = compute_current(tetrahedral_skyrmion, label="uMOI")
+V3 = compute_current(tetrahedral_skyrmion, label="vMOI")
+W3 = compute_current(tetrahedral_skyrmion, label="wMOI")
+
+@test isapprox(U3[1,1],U3[2,2], atol=tol)
+@test isapprox(U3[2,2],U3[3,3], atol=tol)
+
+@test isapprox(W3[1,1],W3[2,2], atol=tol)
+@test isapprox(W3[2,2],W3[3,3], atol=tol)
+
+@test isapprox(V3[1,1],V3[2,2], atol=tol)
+@test isapprox(V3[2,2],V3[3,3], atol=tol)

--- a/test/do_symmetry_tests.jl
+++ b/test/do_symmetry_tests.jl
@@ -4,66 +4,66 @@
 
 using Skyrmions3D
 
-spherically_symmetric_skyrmion = Skyrmion(10,0.2, mpi=1.0)
+spherically_symmetric_skyrmion = Skyrmion(10, 0.2, mpi = 1.0)
 p1(z) = z
 q1(z) = 1
-f1(r) = pi*exp( -(r.^3)./12.0 )
+f1(r) = pi*exp(-(r .^ 3) ./ 12.0)
 make_rational_map!(spherically_symmetric_skyrmion, p1, q1, f1)
 
-U1 = compute_current(spherically_symmetric_skyrmion, label="uMOI")
-V1 = compute_current(spherically_symmetric_skyrmion, label="vMOI")
-W1 = compute_current(spherically_symmetric_skyrmion, label="wMOI")
+U1 = compute_current(spherically_symmetric_skyrmion, label = "uMOI")
+V1 = compute_current(spherically_symmetric_skyrmion, label = "vMOI")
+W1 = compute_current(spherically_symmetric_skyrmion, label = "wMOI")
 
 tol = 1e-10
 
-@test isapprox(U1[1,1],U1[2,2], atol=tol)
-@test isapprox(U1[2,2],U1[3,3], atol=tol)
+@test isapprox(U1[1, 1], U1[2, 2], atol = tol)
+@test isapprox(U1[2, 2], U1[3, 3], atol = tol)
 
-@test isapprox(W1[1,1],W1[2,2], atol=tol)
-@test isapprox(W1[2,2],W1[3,3], atol=tol)
+@test isapprox(W1[1, 1], W1[2, 2], atol = tol)
+@test isapprox(W1[2, 2], W1[3, 3], atol = tol)
 
-@test isapprox(V1[1,1],V1[2,2], atol=tol)
-@test isapprox(V1[2,2],V1[3,3], atol=tol)
+@test isapprox(V1[1, 1], V1[2, 2], atol = tol)
+@test isapprox(V1[2, 2], V1[3, 3], atol = tol)
 
-for a in 1:3, b in 1:3
+for a = 1:3, b = 1:3
     if a != b
-        @test isapprox(U1[a,b], 0, atol=tol)
-        @test isapprox(W1[a,b], 0, atol=tol)
-        @test isapprox(V1[a,b], 0, atol=tol)
+        @test isapprox(U1[a, b], 0, atol = tol)
+        @test isapprox(W1[a, b], 0, atol = tol)
+        @test isapprox(V1[a, b], 0, atol = tol)
     end
 end
 
-cubic_skyrmion = Skyrmion(10,0.4, mpi=1.0)
+cubic_skyrmion = Skyrmion(10, 0.4, mpi = 1.0)
 p4(z) = z^4 + 2.0*sqrt(3.0)*im*z^2 + 1.0;
 q4(z) = z^4 - 2.0*sqrt(3.0)*im*z^2 + 1.0;
-f4(r) = pi*exp( -(r.^3)./12.0 )
+f4(r) = pi*exp(-(r .^ 3) ./ 12.0)
 
 make_rational_map!(cubic_skyrmion, p4, q4, f4)
 
-U4 = compute_current(cubic_skyrmion, label="uMOI")
-V4 = compute_current(cubic_skyrmion, label="vMOI")
-W4 = compute_current(cubic_skyrmion, label="wMOI")
+U4 = compute_current(cubic_skyrmion, label = "uMOI")
+V4 = compute_current(cubic_skyrmion, label = "vMOI")
+W4 = compute_current(cubic_skyrmion, label = "wMOI")
 
 tol = 1e-7
 
-@test isapprox(U4[1,1],U4[2,2], atol=tol)
+@test isapprox(U4[1, 1], U4[2, 2], atol = tol)
 
-@test isapprox(V4[1,1],V4[2,2], atol=tol)
-@test isapprox(V4[2,2],V4[3,3], atol=tol)
+@test isapprox(V4[1, 1], V4[2, 2], atol = tol)
+@test isapprox(V4[2, 2], V4[3, 3], atol = tol)
 
-for a in 1:3, b in 1:3
+for a = 1:3, b = 1:3
     if a != b
-        @test isapprox(U4[a,b], 0, atol=tol)
-        @test isapprox(V4[a,b], 0, atol=tol)
+        @test isapprox(U4[a, b], 0, atol = tol)
+        @test isapprox(V4[a, b], 0, atol = tol)
     end
-    @test isapprox(W4[a,b], 0, atol=tol)
+    @test isapprox(W4[a, b], 0, atol = tol)
 end
 
 # tetrahedral ADHM skyrmion
 
 using Quaternions
 
-tetrahedral_skyrmion = Skyrmion(10,0.4, mpi=1.0)
+tetrahedral_skyrmion = Skyrmion(10, 0.4, mpi = 1.0)
 
 B=3
 
@@ -88,15 +88,15 @@ adhm_data[4, 2] = Quaternion(lam, 0.0, 0.0, 0.0)
 
 make_ADHM!(tetrahedral_skyrmion, adhm_data)
 
-U3 = compute_current(tetrahedral_skyrmion, label="uMOI")
-V3 = compute_current(tetrahedral_skyrmion, label="vMOI")
-W3 = compute_current(tetrahedral_skyrmion, label="wMOI")
+U3 = compute_current(tetrahedral_skyrmion, label = "uMOI")
+V3 = compute_current(tetrahedral_skyrmion, label = "vMOI")
+W3 = compute_current(tetrahedral_skyrmion, label = "wMOI")
 
-@test isapprox(U3[1,1],U3[2,2], atol=tol)
-@test isapprox(U3[2,2],U3[3,3], atol=tol)
+@test isapprox(U3[1, 1], U3[2, 2], atol = tol)
+@test isapprox(U3[2, 2], U3[3, 3], atol = tol)
 
-@test isapprox(W3[1,1],W3[2,2], atol=tol)
-@test isapprox(W3[2,2],W3[3,3], atol=tol)
+@test isapprox(W3[1, 1], W3[2, 2], atol = tol)
+@test isapprox(W3[2, 2], W3[3, 3], atol = tol)
 
-@test isapprox(V3[1,1],V3[2,2], atol=tol)
-@test isapprox(V3[2,2],V3[3,3], atol=tol)
+@test isapprox(V3[1, 1], V3[2, 2], atol = tol)
+@test isapprox(V3[2, 2], V3[3, 3], atol = tol)


### PR DESCRIPTION
Adds some correctness symmetry tests: makes the B=1,4 (RM) and 3 (ADHM) skyrmions and checks their moment of intertia tensors have the correct symmetry.

Re-discovered a bug during this - thought I fixed it before, but never pushed. Oops.

Used this to test out using a pre-commit hook for formatting, which worked great!

Any other tests like this we could add?

EDIT: also modified the doc build so that it doesn't try to export the doc strings of non-exported functions. This allows us to add docstrings to non-exported functions without Documenter failing.