### PR TITLE
Add save/load functionality

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.11.6"
 manifest_format = "2.0"
-project_hash = "7a6a77b50c91901d6c643126ea2b5a305e08fd82"
+project_hash = "2b8eeb2f08dd7632505b4dcddd440e613d710d57"
 
 [[deps.AbstractFFTs]]
 deps = ["LinearAlgebra"]
@@ -462,11 +462,35 @@ git-tree-sha1 = "53bb909d1151e57e2484c3d1b53e19552b887fb2"
 uuid = "42e2da0e-8278-4e71-bc24-59509adca0fe"
 version = "1.0.2"
 
+[[deps.HDF5]]
+deps = ["Compat", "HDF5_jll", "Libdl", "MPIPreferences", "Mmap", "Preferences", "Printf", "Random", "Requires", "UUIDs"]
+git-tree-sha1 = "e856eef26cf5bf2b0f95f8f4fc37553c72c8641c"
+uuid = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
+version = "0.17.2"
+
+    [deps.HDF5.extensions]
+    MPIExt = "MPI"
+
+    [deps.HDF5.weakdeps]
+    MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
+
+[[deps.HDF5_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "LazyArtifacts", "LibCURL_jll", "Libdl", "MPICH_jll", "MPIPreferences", "MPItrampoline_jll", "MicrosoftMPI_jll", "OpenMPI_jll", "OpenSSL_jll", "TOML", "Zlib_jll", "libaec_jll"]
+git-tree-sha1 = "e94f84da9af7ce9c6be049e9067e511e17ff89ec"
+uuid = "0234f1f7-429e-5d53-9886-15a909be8d59"
+version = "1.14.6+0"
+
 [[deps.HarfBuzz_jll]]
 deps = ["Artifacts", "Cairo_jll", "Fontconfig_jll", "FreeType2_jll", "Glib_jll", "Graphite2_jll", "JLLWrappers", "Libdl", "Libffi_jll"]
 git-tree-sha1 = "f923f9a774fcf3f5cb761bfa43aeadd689714813"
 uuid = "2e76f6c2-a576-52d4-95c1-20adfe4de566"
 version = "8.5.1+0"
+
+[[deps.Hwloc_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "XML2_jll", "Xorg_libpciaccess_jll"]
+git-tree-sha1 = "3d468106a05408f9f7b6f161d9e7715159af247b"
+uuid = "e33a78d0-f292-5ffc-b300-72abe9b543c8"
+version = "2.12.2+0"
 
 [[deps.HypergeometricFunctions]]
 deps = ["LinearAlgebra", "OpenLibm_jll", "SpecialFunctions"]
@@ -787,6 +811,24 @@ git-tree-sha1 = "282cadc186e7b2ae0eeadbd7a4dffed4196ae2aa"
 uuid = "856f044c-d86e-5d09-b602-aeab76dc8ba7"
 version = "2025.2.0+0"
 
+[[deps.MPICH_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Hwloc_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "MPIPreferences", "TOML"]
+git-tree-sha1 = "d72d0ecc3f76998aac04e446547259b9ae4c265f"
+uuid = "7cb0a576-ebde-5e09-9194-50597f1243b4"
+version = "4.3.1+0"
+
+[[deps.MPIPreferences]]
+deps = ["Libdl", "Preferences"]
+git-tree-sha1 = "c105fe467859e7f6e9a852cb15cb4301126fac07"
+uuid = "3da0fdf6-3ccc-4f1b-acd9-58baa6c99267"
+version = "0.1.11"
+
+[[deps.MPItrampoline_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "MPIPreferences", "TOML"]
+git-tree-sha1 = "e214f2a20bdd64c04cd3e4ff62d3c9be7e969a59"
+uuid = "f1f71cc9-e9ae-5b93-9b94-4fe0e1ad3748"
+version = "5.5.4+0"
+
 [[deps.MacroTools]]
 git-tree-sha1 = "1e0228a030642014fe5cfe68c2c0a818f9e3f522"
 uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
@@ -829,6 +871,12 @@ version = "2.28.6+0"
 git-tree-sha1 = "5705d4f32545f7bcecdff75759a20d17812e5caf"
 uuid = "e6723b4c-ebff-59f1-b4b7-d97aa5274f73"
 version = "0.7.0"
+
+[[deps.MicrosoftMPI_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "bc95bf4149bf535c09602e3acdf950d9b4376227"
+uuid = "9237b28f-5490-5468-be7b-bb81f5f5e6cf"
+version = "10.1.4+3"
 
 [[deps.Missings]]
 deps = ["DataAPI"]
@@ -913,6 +961,12 @@ version = "3.2.4+0"
 deps = ["Artifacts", "Libdl"]
 uuid = "05823500-19ac-5b8b-9628-191a04bc5112"
 version = "0.8.5+0"
+
+[[deps.OpenMPI_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Hwloc_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "MPIPreferences", "TOML", "Zlib_jll"]
+git-tree-sha1 = "ec764453819f802fc1e144bfe750c454181bd66d"
+uuid = "fe0851c0-eecd-5654-98d4-656369965a5c"
+version = "5.0.8+0"
 
 [[deps.OpenSSL_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
@@ -1396,6 +1450,12 @@ git-tree-sha1 = "c1a7aa6219628fcd757dede0ca95e245c5cd9511"
 uuid = "efce3f68-66dc-5838-9240-27a6d6f5f9b6"
 version = "1.0.0"
 
+[[deps.XML2_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Libiconv_jll", "Zlib_jll"]
+git-tree-sha1 = "b8b243e47228b4a3877f1dd6aee0c5d56db7fcf4"
+uuid = "02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"
+version = "2.13.6+1"
+
 [[deps.XZ_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
 git-tree-sha1 = "fee71455b0aaa3440dfdd54a9a36ccef829be7d4"
@@ -1432,6 +1492,12 @@ git-tree-sha1 = "7ed9347888fac59a618302ee38216dd0379c480d"
 uuid = "ea2f1a96-1ddc-540d-b46f-429655e07cfa"
 version = "0.9.12+0"
 
+[[deps.Xorg_libpciaccess_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Zlib_jll"]
+git-tree-sha1 = "4909eb8f1cbf6bd4b1c30dd18b2ead9019ef2fad"
+uuid = "a65dc6b1-eb27-53a1-bb3e-dea574b5389e"
+version = "0.18.1+0"
+
 [[deps.Xorg_libxcb_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libXau_jll", "Xorg_libXdmcp_jll"]
 git-tree-sha1 = "bfcaf7ec088eaba362093393fe11aa141fa15422"
@@ -1460,6 +1526,12 @@ deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
 git-tree-sha1 = "51b5eeb3f98367157a7a12a1fb0aa5328946c03c"
 uuid = "9a68df92-36a6-505f-a73e-abb412b6bfb4"
 version = "0.2.3+0"
+
+[[deps.libaec_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "1aa23f01927b2dac46db77a56b31088feee0a491"
+uuid = "477f73a3-ac25-53e9-8cc3-50b2fa2566f0"
+version = "1.1.4+0"
 
 [[deps.libaom_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]

--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ version = "1.0.0-DEV"
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
 GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
+HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
 Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
 JuliaFormatter = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
@@ -16,11 +17,14 @@ Meshing = "e6723b4c-ebff-59f1-b4b7-d97aa5274f73"
 Quaternions = "94ee1d12-ae83-5a48-8b1c-48b8ff168ae0"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [compat]
 CairoMakie = "0.12.12"
+HDF5 = "0.17.2"
 JuliaFormatter = "2.1.6"
 Quaternions = "0.7.6"
+TOML = "1.0.3"
 julia = "1"
 
 [extras]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -7,7 +7,7 @@ makedocs(
     authors = "Chris Halcrow",
     pages = [
         "Home" => "index.md",
-        "Create Skyrmion" => "making_skyrmions.md",
+        "Make, save and load" => "making_skyrmions.md",
         "Transform and Combine" => "transform.md",
         "Compute properties" => "properties.md",
         "Flow" => "flow.md",
@@ -17,7 +17,7 @@ makedocs(
         "Contribute" => "contributing.md",
     ],
     repo = Documenter.Remotes.GitHub("chrishalcrow", "Skyrmions3D.jl"),
-    checkdocs=:exports,
+    checkdocs = :exports,
 )
 
 deploydocs(; repo = "github.com/chrishalcrow/Skyrmions3D.jl")

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -9,6 +9,13 @@ Skyrmion
 Grid
 ```
 
+## Save/load
+
+```@docs
+save_skyrmion
+load_skyrmion
+```
+
 ## Set up the system
 
 ```@docs

--- a/docs/src/making_skyrmions.md
+++ b/docs/src/making_skyrmions.md
@@ -74,13 +74,13 @@ make_ADHM!(my_skyrmion, adhm_data)
 ## Save your Skyrmion
 
 Once you've created your skyrmion, you can save a copy of it in a folder. This folder will contain
-the pion fields in the. [`HDF5` format](https://en.wikipedia.org/wiki/Hierarchical_Data_Format). These files
+the pion fields in the [`HDF5` format](https://en.wikipedia.org/wiki/Hierarchical_Data_Format). These files
 can be read by all popular programming languages, and allows for excellent compression. In addition we
 save a human-readable `metadata.toml` file, containing the metadata associated with the Skyrmion, such as
 it's grid properties. Overall the folder structure is
 
 ``` bash
-output_folder/
+my_output_folder/
     pion_field.h5
     metadata.toml
 ```
@@ -88,7 +88,7 @@ output_folder/
 To save your skyrmion, simply run
 
 ``` julia
-save_skyrmion(my_skyrmion, folder="my_beautiful_skyrmion")
+save_skyrmion(my_skyrmion, path="path/to/my_output_folder")
 ```
 
 By default, this function will not overwrite existing folders. You can add additional metadata by passing
@@ -97,5 +97,5 @@ a dictionary to the `additional_metadata` argument. Read more in the API.
 To load a save Skyrion, use the `load_skyrmion` function:
 
 ``` julia
-loaded_skyrmion = load_skyrmion("my_beautiful_skyrmion")
+loaded_skyrmion = load_skyrmion("path/to/my_output_folder")
 ```

--- a/docs/src/making_skyrmions.md
+++ b/docs/src/making_skyrmions.md
@@ -1,4 +1,4 @@
-# Making Skyrmions
+# Make, save and load Skyrmions
 
 Skyrmions in Skyrmions3D are represented by the `Skyrmion` struct. This contains all the information needed to reproduce the skyrmion: it's pion field, grid, pion mass etc. You can create a Skyrmion by passing some of these parameters, for example
 
@@ -71,9 +71,31 @@ adhm_data[3,2] = Quaternion(-1.0,0.0,0.0,0.0)*lam/sqrt(2)
 make_ADHM!(my_skyrmion, adhm_data)
 ```
 
+## Save your Skyrmion
 
+Once you've created your skyrmion, you can save a copy of it in a folder. This folder will contain
+the pion fields in the. [`HDF5` format](https://en.wikipedia.org/wiki/Hierarchical_Data_Format). These files
+can be read by all popular programming languages, and allows for excellent compression. In addition we
+save a human-readable `metadata.toml` file, containing the metadata associated with the Skyrmion, such as
+it's grid properties. Overall the folder structure is
 
+``` bash
+output_folder/
+    pion_field.h5
+    metadata.toml
+```
 
+To save your skyrmion, simply run
 
+``` julia
+save_skyrmion(my_skyrmion, folder="my_beautiful_skyrmion")
+```
 
+By default, this function will not overwrite existing folders. You can add additional metadata by passing
+a dictionary to the `additional_metadata` argument. Read more in the API.
 
+To load a save Skyrion, use the `load_skyrmion` function:
+
+``` julia
+loaded_skyrmion = load_skyrmion("my_beautiful_skyrmion")
+```

--- a/src/Skyrmions3D.jl
+++ b/src/Skyrmions3D.jl
@@ -106,7 +106,17 @@ Skyrmion(
     false,
 )
 
-function save_skyrmion(skyrmion, folder; overwrite = false)
+"""
+    save_skyrmion(skyrmion::Skyrmion, folder, overwrite, additional_metadata)
+
+Save a skyrmion to a folder `folder`. If `overwrite` is `true`, function will delete the given
+folder (if valid Skyrmion3D output) and replace with new data. User can specify additional metadata
+by specifying a dict `additional_metadata`.
+
+See also [`load_skyrmion`](@ref). 
+
+"""
+function save_skyrmion(skyrmion, folder; additional_metadata = Dict(), overwrite = false)
 
     if (overwrite == false) & isdir(folder)
         @warn "Folder already exists. To overwrite pass `overwrite = true` to the save funciton."
@@ -134,6 +144,7 @@ function save_skyrmion(skyrmion, folder; overwrite = false)
         "ee" => skyrmion.ee,
         "mpi" => skyrmion.mpi,
         "physical" => skyrmion.physical,
+        "additional_metadata" => additional_metadata,
     )
 
     open(joinpath(folder, "metadata.toml"), "w") do io
@@ -154,7 +165,14 @@ function save_skyrmion(skyrmion, folder; overwrite = false)
 
 end
 
+"""
+    load_skyrmion(folder)
 
+Loads a Skyrmion, which has been previously saved in `folder`. Returns the loaded skyrmion.
+
+See also [`save_skyrmion`](@ref). 
+
+"""
 function load_skyrmion(folder)
 
     metadata_path = joinpath(folder, "metadata.toml")

--- a/src/Skyrmions3D.jl
+++ b/src/Skyrmions3D.jl
@@ -111,30 +111,30 @@ Skyrmion(
 )
 
 """
-    save_skyrmion(skyrmion::Skyrmion, folder, overwrite, additional_metadata)
+    save_skyrmion(skyrmion::Skyrmion, path, overwrite, additional_metadata)
 
-Save a skyrmion to a folder `folder`. If `overwrite` is `true`, function will delete the given
+Save a skyrmion to a folder at `path`. If `overwrite` is `true`, function will delete the given
 folder (if valid Skyrmion3D output) and replace with new data. User can specify additional metadata
 by specifying a dict `additional_metadata`.
 
 See also [`load_skyrmion`](@ref). 
 
 """
-function save_skyrmion(skyrmion, folder; additional_metadata = Dict(), overwrite = false)
+function save_skyrmion(skyrmion, path; additional_metadata = Dict(), overwrite = false)
 
-    if (overwrite == false) & isdir(folder)
+    if (overwrite == false) & isdir(path)
         @warn "Folder already exists. To overwrite pass `overwrite = true` to the save funciton."
         return
     end
 
     # Be careful when deleting - only delete a folder that looks like a Skyrmions3D output
     if overwrite == true
-        rm(joinpath(folder, "metadata.toml"))
-        rm(joinpath(folder, "pion_field.h5"))
-        rm(folder, recursive = false)
+        rm(joinpath(path, "metadata.toml"))
+        rm(joinpath(path, "pion_field.h5"))
+        rm(path, recursive = false)
     end
 
-    mkdir(folder)
+    mkdir(path)
 
     grid_metadata = Dict(
         "lp" => skyrmion.grid.lp,
@@ -152,11 +152,11 @@ function save_skyrmion(skyrmion, folder; additional_metadata = Dict(), overwrite
         "additional_metadata" => additional_metadata,
     )
 
-    open(joinpath(folder, "metadata.toml"), "w") do io
+    open(joinpath(path, "metadata.toml"), "w") do io
         TOML.print(io, skyrmion_metadata)
     end
 
-    h5open(joinpath(folder, "pion_field.h5"), "w") do file
+    h5open(joinpath(path, "pion_field.h5"), "w") do file
         dataset = create_dataset(
             file,
             "pion_field",
@@ -171,24 +171,24 @@ function save_skyrmion(skyrmion, folder; additional_metadata = Dict(), overwrite
 end
 
 """
-    load_skyrmion(folder)
+    load_skyrmion(path)
 
-Loads a Skyrmion, which has been previously saved in `folder`. Returns the loaded skyrmion.
+Loads a Skyrmion, which has been previously saved in `path`. Returns the loaded skyrmion.
 
 See also [`save_skyrmion`](@ref). 
 
 """
-function load_skyrmion(folder)
+function load_skyrmion(path)
 
-    metadata_path = joinpath(folder, "metadata.toml")
+    metadata_path = joinpath(path, "metadata.toml")
 
     if isfile(metadata_path) == false
-        @warn "No `metadata.toml` file in `folder`. Cannot load."
+        @warn "No `metadata.toml` file in `path`. Cannot load."
         return
     end
 
     metadata = nothing
-    open(joinpath(folder, "metadata.toml"), "r") do io
+    open(joinpath(path, "metadata.toml"), "r") do io
         metadata = TOML.parse(io)
     end
 
@@ -214,7 +214,7 @@ function load_skyrmion(folder)
 
     set_physical!(loaded_skyrmion, physical)
     set_boundary_conditions!(loaded_skyrmion, boundary_conditions)
-    pion_field = h5read(joinpath(folder, "pion_field.h5"), "pion_field")
+    pion_field = h5read(joinpath(path, "pion_field.h5"), "pion_field")
     loaded_skyrmion.pion_field = pion_field
 
     return loaded_skyrmion
@@ -384,12 +384,7 @@ Also used to turn off physical units by setting `is_physical=false`.
 The physical energy unit is ``\\frac{F_\\pi}{4e}`` MeV and the physical length unit is ``\\frac{2\\hbar}{e F_\\pi}`` fm (where ``\\hbar \\approx 197.327`` MeV fm is the reduced Planck constant).  
 
 """
-function set_physical!(
-    skyrmion,
-    physical;
-    Fpi = skyrmion.Fpi,
-    ee = skyrmion.ee,
-)
+function set_physical!(skyrmion, physical; Fpi = skyrmion.Fpi, ee = skyrmion.ee)
 
     skyrmion.physical = physical
 

--- a/src/Skyrmions3D.jl
+++ b/src/Skyrmions3D.jl
@@ -6,17 +6,29 @@ using Makie, CairoMakie, Requires, Meshing, GeometryBasics, Colors
 # Functionality
 using StaticArrays, LinearAlgebra, Interpolations
 
+# Save/load
+using TOML, HDF5
+
 export Skyrmion,
     get_grid, get_field, set_mpi!, set_lattice!, set_Fpi!, set_ee!, set_physical!
 export set_periodic!, set_dirichlet!, set_neumann!, set_bounary_conditions!
 export check_if_normalised, normer!, normer
+export save_skyrmion, load_skyrmion
 
 include("transform.jl")
 export translate_sk, translate_sk!, isorotate_sk, isorotate_sk!, rotate_sk!, rotate_sk
 export product_approx, product_approx!, center_skyrmion!, evaluate_sk
 
 include("properties.jl")
-export Energy, get_energy_density!, Baryon, get_baryon_density!, center_of_mass, rms_baryon, compute_current, overview, sphericity
+export Energy,
+    get_energy_density!,
+    Baryon,
+    get_baryon_density!,
+    center_of_mass,
+    rms_baryon,
+    compute_current,
+    overview,
+    sphericity
 
 include("initialise.jl")
 export make_rational_map!, make_RM_product!, make_ADHM!
@@ -94,6 +106,96 @@ Skyrmion(
     false,
 )
 
+function save_skyrmion(skyrmion, folder; overwrite = false)
+
+    if (overwrite == false) & isdir(folder)
+        @warn "Folder already exists. To overwrite pass `overwrite = true` to the save funciton."
+        return
+    end
+
+    # Be careful when deleting - only delete a folder that looks like a Skyrmions3D output
+    if overwrite == true
+        rm(joinpath(folder, "metadata.toml"))
+        rm(joinpath(folder, "pion_field.h5"))
+        rm(folder, recursive = false)
+    end
+
+    mkdir(folder)
+
+    grid_metadata = Dict(
+        "lp" => skyrmion.grid.lp,
+        "ls" => skyrmion.grid.ls,
+        "boundary_conditions" => skyrmion.grid.boundary_conditions,
+    )
+
+    skyrmion_metadata = Dict(
+        "grid" => grid_metadata,
+        "Fpi" => skyrmion.Fpi,
+        "ee" => skyrmion.ee,
+        "mpi" => skyrmion.mpi,
+        "physical" => skyrmion.physical,
+    )
+
+    open(joinpath(folder, "metadata.toml"), "w") do io
+        TOML.print(io, skyrmion_metadata)
+    end
+
+    h5open(joinpath(folder, "pion_field.h5"), "w") do file
+        dataset = create_dataset(
+            file,
+            "pion_field",
+            datatype(eltype(skyrmion.pion_field)),
+            dataspace(size(skyrmion.pion_field)),
+            compress = 6,
+            chunk = (size(skyrmion.pion_field)[1], size(skyrmion.pion_field)[2], 1, 1),
+        )
+        write(dataset, skyrmion.pion_field)
+    end
+
+end
+
+
+function load_skyrmion(folder)
+
+    metadata_path = joinpath(folder, "metadata.toml")
+
+    if isfile(metadata_path) == false
+        @warn "No `metadata.toml` file in `folder`. Cannot load."
+        return
+    end
+
+    metadata = nothing
+    open(joinpath(folder, "metadata.toml"), "r") do io
+        metadata = TOML.parse(io)
+    end
+
+    lp = metadata["grid"]["lp"]
+    ls = metadata["grid"]["ls"]
+    boundary_conditions = metadata["grid"]["boundary_conditions"]
+
+    mpi = metadata["mpi"]
+    ee = metadata["ee"]
+    Fpi = metadata["Fpi"]
+    physical = metadata["physical"]
+
+    loaded_skyrmion = Skyrmion(
+        lp,
+        ls,
+        boundary_conditions = boundary_conditions,
+        mpi = mpi,
+        ee = ee,
+        Fpi = Fpi,
+    )
+
+    set_physical!(loaded_skyrmion, physical)
+
+    pion_field = h5read(joinpath(folder, "pion_field.h5"), "pion_field")
+    loaded_skyrmion.pion_field = pion_field
+
+    return loaded_skyrmion
+
+
+end
 
 """
     get_field(skyrmion::Skyrmion)

--- a/src/initialise.jl
+++ b/src/initialise.jl
@@ -190,7 +190,7 @@ function make_rational_map!(
     end
 
     if skyrmion.grid.boundary_conditions == "dirichlet"
-        set_dirichlet_boudary!(skyrmion)
+        set_dirichlet_vacuum!(skyrmion)
     end
 
 end
@@ -395,7 +395,7 @@ function make_ADHM!(an_ADHM_skyrmion, L, M = nothing; tsteps = 42)
         B = size(L)[2]
         M = L[2:(B+1), 1:B]
         L = L[1, 1:B]
-    end 
+    end
 
     B = size(L)[1]
 

--- a/src/transform.jl
+++ b/src/transform.jl
@@ -80,8 +80,6 @@ function translate_sk(skyrmion; X = [0.0, 0.0, 0.0])
 
     sky_temp = deepcopy(skyrmion)
 
-    vac = [0.0, 0.0, 0.0, 1.0]
-
     ϕinterp = [
         extrapolate(
             scale(
@@ -102,7 +100,7 @@ function translate_sk(skyrmion; X = [0.0, 0.0, 0.0])
             sky_temp.pion_field[i, j, k, a] =
                 ϕinterp[a](x[1][i] - X[1], x[2][j] - X[2], x[3][k] - X[3])
         else
-            sky_temp.pion_field[i, j, k, a] = vac[a]
+            sky_temp.pion_field[i, j, k, a] = skyrmion.vac[a]
         end
     end
 
@@ -122,7 +120,7 @@ See also [`translate_sk`](@ref).
 """
 function translate_sk!(skyrmion; X = [0.0, 0.0, 0.0])
 
-    tempsk = translate_sk(skyrmion, X=X)
+    tempsk = translate_sk(skyrmion, X = X)
     skyrmion.pion_field .= tempsk.pion_field
 
 end
@@ -137,7 +135,7 @@ See also [`isorotate_sk`](@ref).
 """
 function isorotate_sk!(skyrmion; theta = 0, n = [0, 0, 1])
 
-    tempsk = isorotate_sk(skyrmion, theta=theta, n=n)
+    tempsk = isorotate_sk(skyrmion, theta = theta, n = n)
     skyrmion.pion_field .= tempsk.pion_field
 
 end
@@ -195,7 +193,7 @@ See also [`rotate_sk`](@ref).
 """
 function rotate_sk!(skyrmion; theta = 0, n = [0, 0, 1])
 
-    tempsk = rotate_sk(skyrmion, theta=theta, n=n)
+    tempsk = rotate_sk(skyrmion, theta = theta, n = n)
     skyrmion.pion_field .= tempsk.pion_field
 
 end
@@ -223,8 +221,6 @@ function rotate_sk(skyrmion; theta = 0, n = [0, 0, 1])
 
     sky_temp = deepcopy(skyrmion)
 
-    vac = [0.0, 0.0, 0.0, 1.0]
-
     ϕinterp = [
         extrapolate(
             scale(
@@ -247,7 +243,7 @@ function rotate_sk(skyrmion; theta = 0, n = [0, 0, 1])
             end
         else
             for a = 1:4
-                sky_temp.pion_field[i, j, k, a] = vac[a]
+                sky_temp.pion_field[i, j, k, a] = skyrmion.vac[a]
             end
         end
     end
@@ -273,7 +269,9 @@ function center_skyrmion!(sk)
 
 end
 
-function set_dirichlet_boudary!(sk; vac = [0.0, 0.0, 0.0, 1.0])
+function set_dirichlet_vacuum!(sk)
+
+    vac = sk.vac
 
     for i = 1:sk.grid.lp[1], j = 1:sk.grid.lp[2]
         sk.pion_field[i, j, 1, :] .= vac
@@ -301,14 +299,13 @@ end
 """
     evaluate_sk(skyrmion, y)
 
-Evaluates the Skyrme field at the spatial position `y`, using some fancy interpolation method.
+Evaluates the Skyrme field at the spatial position `y`, using a quadratic B-spline interpolation method.
 
 """
 function evaluate_sk(skyrmion, y)
 
     x = skyrmion.grid.x
-    vac = [0.0, 0.0, 0.0, 1.0]
-    phi=vac
+    phi=skyrmion.vac
 
     phiinterp = [
         extrapolate(

--- a/test/do_initialise_tests.jl
+++ b/test/do_initialise_tests.jl
@@ -1,21 +1,30 @@
 
 using Skyrmions3D
+using Test
+
+
+function test_if_skyrmions_equal(a_skyrmion, b_skyrmion)
+
+    @test a_skyrmion.pion_field == b_skyrmion.pion_field
+    @test a_skyrmion.grid.lp == b_skyrmion.grid.lp
+    @test a_skyrmion.grid.ls == b_skyrmion.grid.ls
+    @test a_skyrmion.mpi == b_skyrmion.mpi
+    @test a_skyrmion.Fpi == b_skyrmion.Fpi
+    @test a_skyrmion.ee == b_skyrmion.ee
+    @test a_skyrmion.physical == b_skyrmion.physical
+    @test a_skyrmion.grid.dirichlet == b_skyrmion.grid.dirichlet
+    @test a_skyrmion.grid.index_grid_x == b_skyrmion.grid.index_grid_x
+    @test a_skyrmion.grid.index_grid_y == b_skyrmion.grid.index_grid_y
+    @test a_skyrmion.grid.index_grid_z == b_skyrmion.grid.index_grid_z
+    @test a_skyrmion.grid.sum_grid == b_skyrmion.grid.sum_grid
+    @test a_skyrmion.vac == b_skyrmion.vac
+
+end
 
 a_skyrmion = Skyrmion(5, 0.2)
 the_same_skyrmion = Skyrmion([5, 5, 5], [0.2, 0.2, 0.2])
 
-@test a_skyrmion.pion_field == the_same_skyrmion.pion_field
-@test a_skyrmion.grid.lp == the_same_skyrmion.grid.lp
-@test a_skyrmion.grid.ls == the_same_skyrmion.grid.ls
-@test a_skyrmion.mpi == the_same_skyrmion.mpi
-@test a_skyrmion.Fpi == the_same_skyrmion.Fpi
-@test a_skyrmion.ee == the_same_skyrmion.ee
-@test a_skyrmion.physical == the_same_skyrmion.physical
-@test a_skyrmion.grid.dirichlet == the_same_skyrmion.grid.dirichlet
-@test a_skyrmion.grid.index_grid_x == the_same_skyrmion.grid.index_grid_x
-@test a_skyrmion.grid.index_grid_y == the_same_skyrmion.grid.index_grid_y
-@test a_skyrmion.grid.index_grid_z == the_same_skyrmion.grid.index_grid_z
-@test a_skyrmion.grid.sum_grid == the_same_skyrmion.grid.sum_grid
+test_if_skyrmions_equal(a_skyrmion, the_same_skyrmion)
 
 # setting stuff
 
@@ -94,3 +103,16 @@ check_if_normalised(a_skyrmion)
 
 a_skyrmion.pion_field[2, 3, 1, 1] = 2.0
 check_if_normalised(normer(a_skyrmion))
+
+
+# wrapper to make a temp directory, which will deleted when tests are completed.
+mktempdir() do tmpdir
+    # Your save/load tests here
+
+    filepath = joinpath(tmpdir, "basic_save")
+    save_skyrmion(a_skyrmion, filepath)
+    loaded_skyrmion = load_skyrmion(filepath)
+
+    test_if_skyrmions_equal(a_skyrmion, loaded_skyrmion)
+
+end

--- a/test/do_initialise_tests.jl
+++ b/test/do_initialise_tests.jl
@@ -1,7 +1,5 @@
 
-using Skyrmions3D
-using Test
-
+using TOML, Skyrmions3D
 
 function test_if_skyrmions_equal(a_skyrmion, b_skyrmion)
 
@@ -107,12 +105,22 @@ check_if_normalised(normer(a_skyrmion))
 
 # wrapper to make a temp directory, which will deleted when tests are completed.
 mktempdir() do tmpdir
-    # Your save/load tests here
 
     filepath = joinpath(tmpdir, "basic_save")
     save_skyrmion(a_skyrmion, filepath)
     loaded_skyrmion = load_skyrmion(filepath)
-
     test_if_skyrmions_equal(a_skyrmion, loaded_skyrmion)
+
+    filepath = joinpath(tmpdir, "with_user_metadata")
+    save_skyrmion(a_skyrmion, filepath, additional_metadata = Dict("some" => "metadata"))
+    loaded_skyrmion = load_skyrmion(filepath)
+    test_if_skyrmions_equal(a_skyrmion, loaded_skyrmion)
+
+    metadata = nothing
+    open(joinpath(filepath, "metadata.toml"), "r") do io
+        metadata = TOML.parse(io)
+    end
+    @test metadata["additional_metadata"]["some"] == "metadata"
+
 
 end

--- a/test/do_transform_tests.jl
+++ b/test/do_transform_tests.jl
@@ -72,8 +72,8 @@ make_rational_map!(b_skyrmion, p, q, f, X = [0.2, 0.0, 0.0])
 center_skyrmion!(a_skyrmion)
 @test center_of_mass(a_skyrmion) ≈ [0.0, 0.0, 0.0]
 
-
-Skyrmions3D.set_dirichlet_boudary!(b_skyrmion, vac = [2.0, 0.2, -0.3, 0.5])
+b_skyrmion.vac = [2.0, 0.2, -0.3, 0.5]
+Skyrmions3D.set_dirichlet_vacuum!(b_skyrmion)
 @test b_skyrmion.pion_field[1, 1, 1, :] == [2.0, 0.2, -0.3, 0.5]
 
 


### PR DESCRIPTION
Adds `save_skyrmion` and `load_skyrmion`. Would close #35 

The function `save_skyrmion(my_skyrmion, "output_folder")` creates the directory:

```
output_folder/
    pion_field.h5
    metadata.toml
```

And this can be loaded using `load_skyrmion`.

User can add additional_metadata by passing a dict to the `additional_metadata` arg.

When adding tests, found a bug that `set_dirichlet!` wasn't updating the `index_grid`. Then noticed that we don't actually support any vacuum values except `[0,0,0,1]`. Fixed by adding `vac` to the `Skyrmion` struct. Actually quite a big change... should've made a separate PR... but here we are!

Also noticed spelling mistake in `set_bounary`.