### PR TITLE
Add DocumenterCitations.jl

### DIFF
--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.11.5"
 manifest_format = "2.0"
-project_hash = "2b52e44c5f5b5e2ce5334fbd6710462694eb041a"
+project_hash = "cfc8609ce501ce32cc606df7a7c1173252443703"
 
 [[deps.ANSIColoredPrinters]]
 git-tree-sha1 = "574baf8110975760d391c710b6341da1afa48d8c"
@@ -87,6 +87,29 @@ version = "1.11.0"
 git-tree-sha1 = "bca794632b8a9bbe159d56bf9e31c422671b35e0"
 uuid = "18cc8868-cbac-4acf-b575-c8ff214dc66f"
 version = "1.3.2"
+
+[[deps.BibInternal]]
+deps = ["TestItems"]
+git-tree-sha1 = "b3107800faf461eca3281f89f8d768f4b3e99969"
+uuid = "2027ae74-3657-4b95-ae00-e2f7d55c3e64"
+version = "0.3.7"
+
+[[deps.BibParser]]
+deps = ["BibInternal", "DataStructures", "Dates", "JSONSchema", "TestItems", "YAML"]
+git-tree-sha1 = "33478bed83bd124ea8ecd9161b3918fb4c70e529"
+uuid = "13533e5b-e1c2-4e57-8cef-cac5e52f6474"
+version = "0.2.2"
+
+[[deps.Bibliography]]
+deps = ["BibInternal", "BibParser", "DataStructures", "Dates", "FileIO", "TestItems", "YAML"]
+git-tree-sha1 = "0f25be9708ae20d7b94d3bf9d0a91defcca4c884"
+uuid = "f1be7e48-bf82-45af-a471-ae754a193061"
+version = "0.3.0"
+
+[[deps.Bijections]]
+git-tree-sha1 = "a2d308fcd4c2fb90e943cf9cd2fbfa9c32b69733"
+uuid = "e2ed5e7c-b2de-5872-ae92-c73ca462fb04"
+version = "0.2.2"
 
 [[deps.Bzip2_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
@@ -183,6 +206,12 @@ git-tree-sha1 = "37ea44092930b1811e666c3bc38065d7d87fcc74"
 uuid = "5ae59095-9a9b-59fe-a467-6f913c188581"
 version = "0.13.1"
 
+[[deps.CommonMark]]
+deps = ["PrecompileTools"]
+git-tree-sha1 = "351d6f4eaf273b753001b2de4dffb8279b100769"
+uuid = "a80b9123-70ca-4bc0-993e-6e3bcb318db6"
+version = "0.9.1"
+
 [[deps.Compat]]
 deps = ["TOML", "UUIDs"]
 git-tree-sha1 = "3a3dfb30697e96a440e4149c8c51bf32f818c0f3"
@@ -272,6 +301,12 @@ deps = ["ANSIColoredPrinters", "AbstractTrees", "Base64", "CodecZlib", "Dates", 
 git-tree-sha1 = "47ffb8f27ffc01e2e57e7ae5365ae5ceef87b03d"
 uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 version = "1.14.1"
+
+[[deps.DocumenterCitations]]
+deps = ["AbstractTrees", "Bibliography", "Bijections", "Dates", "Documenter", "Logging", "Markdown", "MarkdownAST", "OrderedCollections", "Unicode"]
+git-tree-sha1 = "c9953a03a0049333bec89ac254ea28e86fa7a1a9"
+uuid = "daee34ce-89f3-4625-b898-19384cb65244"
+version = "1.4.1"
 
 [[deps.Downloads]]
 deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
@@ -456,6 +491,11 @@ deps = ["Artifacts", "GettextRuntime_jll", "JLLWrappers", "Libdl", "Libffi_jll",
 git-tree-sha1 = "35fbd0cefb04a516104b8e183ce0df11b70a3f1a"
 uuid = "7746bdde-850d-59dc-9ae8-88ece973131d"
 version = "2.84.3+0"
+
+[[deps.Glob]]
+git-tree-sha1 = "97285bbd5230dd766e9ef6749b80fc617126d496"
+uuid = "c27321d9-0574-5035-807b-f59d2c89b15c"
+version = "1.3.1"
 
 [[deps.Graphics]]
 deps = ["Colors", "LinearAlgebra", "NaNMath"]
@@ -647,6 +687,24 @@ git-tree-sha1 = "31e996f0a15c7b280ba9f76636b3ff9e2ae58c9a"
 uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 version = "0.21.4"
 
+[[deps.JSON3]]
+deps = ["Dates", "Mmap", "Parsers", "PrecompileTools", "StructTypes", "UUIDs"]
+git-tree-sha1 = "411eccfe8aba0814ffa0fdf4860913ed09c34975"
+uuid = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
+version = "1.14.3"
+
+    [deps.JSON3.extensions]
+    JSON3ArrowExt = ["ArrowTypes"]
+
+    [deps.JSON3.weakdeps]
+    ArrowTypes = "31f734f8-188a-4ce0-8406-c8a06bd891cd"
+
+[[deps.JSONSchema]]
+deps = ["Downloads", "JSON", "JSON3", "URIs"]
+git-tree-sha1 = "243f1cdb476835d7c249deb9f29ad6b7827da7d3"
+uuid = "7d188eb4-7ad8-530c-ae41-71a32a6d4692"
+version = "1.4.1"
+
 [[deps.JpegTurbo]]
 deps = ["CEnum", "FileIO", "ImageCore", "JpegTurbo_jll", "TOML"]
 git-tree-sha1 = "9496de8fb52c224a2e3f9ff403947674517317d9"
@@ -658,6 +716,17 @@ deps = ["Artifacts", "JLLWrappers", "Libdl"]
 git-tree-sha1 = "eac1206917768cb54957c65a615460d87b455fc1"
 uuid = "aacddb02-875f-59d6-b918-886e6ef4fbf8"
 version = "3.1.1+0"
+
+[[deps.JuliaFormatter]]
+deps = ["CommonMark", "Glob", "JuliaSyntax", "PrecompileTools", "TOML"]
+git-tree-sha1 = "f512fefd5fdc7dd1ca05778f08f91e9e4c9fdc37"
+uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
+version = "2.1.6"
+
+[[deps.JuliaSyntax]]
+git-tree-sha1 = "937da4713526b96ac9a178e2035019d3b78ead4a"
+uuid = "70703baa-626e-46a2-a12c-08ffd08c73b4"
+version = "0.4.10"
 
 [[deps.KernelDensity]]
 deps = ["Distributions", "DocStringExtensions", "FFTW", "Interpolations", "StatsBase"]
@@ -1219,7 +1288,7 @@ uuid = "45858cf5-a6b0-47a3-bbea-62219f50df47"
 version = "0.1.5"
 
 [[deps.Skyrmions3D]]
-deps = ["CairoMakie", "Colors", "GeometryBasics", "Interpolations", "LaTeXStrings", "LinearAlgebra", "Makie", "Meshing", "Quaternions", "Requires", "StaticArrays"]
+deps = ["CairoMakie", "Colors", "GeometryBasics", "Interpolations", "JuliaFormatter", "LaTeXStrings", "LinearAlgebra", "Makie", "Meshing", "Quaternions", "Requires", "StaticArrays"]
 path = ".."
 uuid = "1ccad2fe-a5c3-464e-b06e-022e005d04e0"
 version = "1.0.0-DEV"
@@ -1310,6 +1379,12 @@ weakdeps = ["ChainRulesCore", "InverseFunctions"]
     StatsFunsChainRulesCoreExt = "ChainRulesCore"
     StatsFunsInverseFunctionsExt = "InverseFunctions"
 
+[[deps.StringEncodings]]
+deps = ["Libiconv_jll"]
+git-tree-sha1 = "b765e46ba27ecf6b44faf70df40c57aa3a547dcb"
+uuid = "69024149-9ee7-55f6-a4c4-859efe599b68"
+version = "0.3.7"
+
 [[deps.StructArrays]]
 deps = ["ConstructionBase", "DataAPI", "Tables"]
 git-tree-sha1 = "9537ef82c42cdd8c5d443cbc359110cbb36bae10"
@@ -1330,6 +1405,12 @@ version = "0.6.21"
     LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
     SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
     StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+
+[[deps.StructTypes]]
+deps = ["Dates", "UUIDs"]
+git-tree-sha1 = "159331b30e94d7b11379037feeb9b690950cace8"
+uuid = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"
+version = "1.11.0"
 
 [[deps.StyledStrings]]
 uuid = "f489334b-da3d-4c2e-b8f0-e476e12c162b"
@@ -1377,6 +1458,11 @@ deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 version = "1.11.0"
 
+[[deps.TestItems]]
+git-tree-sha1 = "42fd9023fef18b9b78c8343a4e2f3813ffbcefcb"
+uuid = "1c621080-faea-4a02-84b6-bbd5e436b8fe"
+version = "1.0.0"
+
 [[deps.TiffImages]]
 deps = ["ColorTypes", "DataStructures", "DocStringExtensions", "FileIO", "FixedPointNumbers", "IndirectArrays", "Inflate", "Mmap", "OffsetArrays", "PkgVersion", "PrecompileTools", "ProgressMeter", "SIMD", "UUIDs"]
 git-tree-sha1 = "02aca429c9885d1109e58f400c333521c13d48a0"
@@ -1392,6 +1478,11 @@ version = "0.11.3"
 git-tree-sha1 = "4d4ed7f294cda19382ff7de4c137d24d16adc89b"
 uuid = "981d1d27-644d-49a2-9326-4793e63143c3"
 version = "0.1.0"
+
+[[deps.URIs]]
+git-tree-sha1 = "bef26fb046d031353ef97a82e3fdb6afe7f21b1a"
+uuid = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
+version = "1.6.1"
 
 [[deps.UUIDs]]
 deps = ["Random", "SHA"]
@@ -1485,6 +1576,12 @@ deps = ["Artifacts", "JLLWrappers", "Libdl"]
 git-tree-sha1 = "a63799ff68005991f9d9491b6e95bd3478d783cb"
 uuid = "c5fb5394-a638-5e4d-96e5-b29de1b5cf10"
 version = "1.6.0+0"
+
+[[deps.YAML]]
+deps = ["Base64", "Dates", "Printf", "StringEncodings"]
+git-tree-sha1 = "2f58ac39f64b41fb812340347525be3b590cce3b"
+uuid = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
+version = "0.4.14"
 
 [[deps.Zlib_jll]]
 deps = ["Libdl"]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+DocumenterCitations = "daee34ce-89f3-4625-b898-19384cb65244"
 Skyrmions3D = "1ccad2fe-a5c3-464e-b06e-022e005d04e0"
 
 [compat]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,4 +1,9 @@
-using Documenter, Skyrmions3D
+using Documenter, Skyrmions3D, DocumenterCitations
+
+bib = CitationBibliography(
+    joinpath(@__DIR__, "../paper/paper.bib");
+    style=:numeric
+)
 
 makedocs(
     modules = [Skyrmions3D],
@@ -15,9 +20,11 @@ makedocs(
         "API" => "api.md",
         "Citations" => "citations.md",
         "Contribute" => "contributing.md",
+        "References" => "references.md",
     ],
     repo = Documenter.Remotes.GitHub("chrishalcrow", "Skyrmions3D.jl"),
-    checkdocs = :exports,
+    checkdocs=:exports;
+    plugins=[bib]
 )
 
 deploydocs(; repo = "github.com/chrishalcrow/Skyrmions3D.jl")

--- a/docs/src/citations.md
+++ b/docs/src/citations.md
@@ -1,6 +1,8 @@
 # Publications citing Skyrmions3D
 
-Below is an (incomplete) list of publications that cite Skyrmions3D. The publications are listed in chronological order. See the section below on how to cite Skyrmions3D in your publication. 
+Below is an (incomplete) list of publications that cite Skyrmions3D.
+The publications are listed in chronological order.
+See the section below on how to cite Skyrmions3D in your publication.
 
 If you have just cited Skyrmions3D in your publication, please consider adding it to this list by [raising a pull request](https://github.com/chrishalcrow/Skyrmions3D.jl/pulls), or get in touch so we can add it. 
 
@@ -12,4 +14,5 @@ If you have just cited Skyrmions3D in your publication, please consider adding i
 
 # How to cite Skyrmions3D
 
-In the root directory of the repository you will see a file called `CITATION.cff`, which provides the necessary details to cite the project. GitHub provides the functionality to export this citation in APA or BibTeX format, [see more here](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files). 
+In the root directory of the repository you will see a file called `CITATION.cff`, which provides the necessary details to cite the project.
+GitHub provides the functionality to export this citation in APA or BibTeX format, [see more here](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files).

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -46,12 +46,12 @@ You can view the documentation by opening the file `<project_directory>/docs/bui
 
 ## Using a pre-commit hook to format your code
 
-We use [`JuliaFormatter`](https://github.com/domluna/JuliaFormatter.jl) to format our code in a
-consistent way. It can be annoying to remember to run this every time you make code changes. A 
-solution is to create a pre-commit hook in your development workflow. This checks and updates
-the formatting of any code that you are trying to commit to the project, *before* you commit it.
+We use [`JuliaFormatter`](https://github.com/domluna/JuliaFormatter.jl) to format our code in a consistent way.
+It can be annoying to remember to run this every time you make code changes.
+A solution is to create a pre-commit hook in your development workflow.
+This checks and updates the formatting of any code that you are trying to commit to the project, *before* you commit it.
 
-To set this up, you need to install pre-commit. One way to do this is using `uvx`. First, 
-[install uv](https://docs.astral.sh/uv/getting-started/installation/). Then, go to the Skyrmions3D.jl
-folder using Terminal and run `uvx pre-commit install`. This will set up a "hook" so that 
-the pre-commit defined in `.pre-commit-config.yaml` will run before you `git commit` any files.
+To set this up, you need to install pre-commit.
+One way to do this is using `uvx`.
+First, [install uv](https://docs.astral.sh/uv/getting-started/installation/).
+Then, go to the Skyrmions3D.jl folder using Terminal and run `uvx pre-commit install`. This will set up a "hook" so that the pre-commit defined in `.pre-commit-config.yaml` will run before you `git commit` any files.

--- a/docs/src/flow.md
+++ b/docs/src/flow.md
@@ -54,7 +54,7 @@ Note that, depending on your boundary conditions and lattice size, your specifie
 
 ## Arrested Newton Flow
 
-A more efficient algorith is the Newton Flow method.
+A more efficient algorithm is the Newton Flow method.
 This models the second order differential equation
 
 ```math

--- a/docs/src/flow.md
+++ b/docs/src/flow.md
@@ -1,6 +1,7 @@
 # Flow
 
-After generating an initial Skyrmion, you can evolve it in a number of ways. Currently, only energy minimising flows are implemented in `Skyrmions3D`. 
+After generating an initial Skyrmion, you can evolve it in a number of ways.
+Currently, only energy minimising flows are implemented in `Skyrmions3D`.
 
 ## Gradient Flow
 
@@ -26,7 +27,8 @@ You can apply a gradient flow like so:
 gradient_flow!(skyrmion)
 ```
 
-When you just pass the skyrmion, the algorithm will get applied for one step with an automatically chosen time-step. If you'd like to run the gradient flow for a bit longer (advised!) or for your own custom time-step, you can as follows:
+When you just pass the skyrmion, the algorithm will get applied for one step with an automatically chosen time-step.
+If you'd like to run the gradient flow for a bit longer (advised!) or for your own custom time-step, you can as follows:
 
 ```julia
 gradient_flow!(skyrmion, steps=100, dt=0.0001)
@@ -52,13 +54,16 @@ Note that, depending on your boundary conditions and lattice size, your specifie
 
 ## Arrested Newton Flow
 
-A more efficient algorith is the Newton Flow method. This models the second order differential equation
+A more efficient algorith is the Newton Flow method.
+This models the second order differential equation
 
 ```math
 \ddot{\boldsymbol{\pi}} = -\frac{\delta E}{\delta \boldsymbol{\pi}}
 ```
 
-But whenever the energy increases, the velocity is reset to zero. This has two advantages: usually, the minimum is found in less flow time; and the second-order time evolution allows for a larger time-step. Flow using Arrested Newton as follows:
+But whenever the energy increases, the velocity is reset to zero.
+This has two advantages: usually, the minimum is found in less flow time; and the second-order time evolution allows for a larger time-step.
+Flow using Arrested Newton as follows:
 
 ```julia
 arrested_newton_flow!(skyrmion, tolerance=0.01)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -8,21 +8,31 @@ A [Julia](http://julialang.org) package for creating, manipulating and probing S
 
 If you don't have it, install [Julia](https://docs.julialang.org/en/v1/manual/installation/).
 
-Once Julia is installed, you can enter the language REPL by typing `julia` into your terminal / command line. When inside, you should see `julia>` at the left-hand side of your terminal.
+Once Julia is installed, you can enter the language REPL by typing `julia` into your terminal / command line.
+When inside, you should see `julia>` at the left-hand side of your terminal.
 
-Now go into package mode by typing `]`. Now something like `@(v1.11) >` should appear at the left-hand side of your terminal. You are now in Julia's package manager. From here, you can install `Skyrmions3D` by typing
+Now go into package mode by typing `]`.
+Now something like `@(v1.11) >` should appear at the left-hand side of your terminal.
+You are now in Julia's package manager.
+From here, you can install `Skyrmions3D` by typing
 
-`add https://github.com/chrishalcrow/Skyrmions3D.jl.git`
+```
+add https://github.com/chrishalcrow/Skyrmions3D.jl.git
+```
 
-When installing the package, Julia will install all other packages `Skyrmions3D` depends on. This might take a little while.
+When installing the package, Julia will install all other packages `Skyrmions3D` depends on.
+This might take a little while.
 
-Once it's installed, go back to the Julia REPL (either by typing backspace from package mode, or by typing `julia` into your base terminal). You can now "use" Skyrmions3D by typing `using Skyrmions3D`. If this works, you've installed the package!
+Once it's installed, go back to the Julia REPL (either by typing backspace from package mode, or by typing `julia` into your base terminal).
+You can now "use" Skyrmions3D by typing `using Skyrmions3D`.
+If this works, you've installed the package!
 
 If you have any problems installing the package, please post an [issue on the github page](https://github.com/chrishalcrow/Skyrmions3D.jl/issues).
 
 ### Learning resources
 
-Details of how to make, transform, compute properties of, flow and visualise skyrmions can be found in the sidebar. The API contains descriptions of all exposed functions from the package.
+Details of how to make, transform, compute properties of, flow and visualise skyrmions can be found in the sidebar.
+The API contains descriptions of all exposed functions from the package.
 
 There is  a tutorial available on the main [github](https://github.com/chrishalcrow/Skyrmions3D.jl.git) repo, either as a Julia file or a Jupyter notepad.
 
@@ -30,4 +40,6 @@ I have also made [one](https://youtu.be/TI5huk6Rqos) or [two](https://youtu.be/H
 
 ### Authors
 
-I am Chris Halcrow, a research software engineer at the University of Edinburgh. I would love there to be more authors of this package. Please join in.
+I am Chris Halcrow, a research software engineer at the University of Edinburgh.
+I would love there to be more authors of this package.
+Please join in.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -40,6 +40,10 @@ I have also made [one](https://youtu.be/TI5huk6Rqos) or [two](https://youtu.be/H
 
 ### Authors
 
-I am Chris Halcrow, a research software engineer at the University of Edinburgh.
-I would love there to be more authors of this package.
+The current core contributors are:
+ - [Chris Halcrow](https://github.com/chrishalcrow), a research software engineer at the University of Edinburgh,
+ - [Linden Disney-Hogg](https://disneyhogg.github.io/personal_webpage/index.html), a research fellow at the University of Leeds,
+ - [Cas G. Chaudhuri](https://gchaudhuri.dev/), a PhD student at the University of Leeds. 
+
+We would love there to be more authors of this package.
 Please join in.

--- a/docs/src/making_skyrmions.md
+++ b/docs/src/making_skyrmions.md
@@ -30,7 +30,7 @@ So we next want to add some field structure to it...
 ## Rational Maps
 
 A complex rational map is defined by two complex valued polynomials; we call these the numerator `p(z)` and the denominator `q(z)`.
-Given these polynomials, we can create a skyrmion from the [rational map approximation](https://arxiv.org/pdf/hep-th/9705151).
+Given these polynomials, we can create a skyrmion from the [houghtonRationalMapsMonopoles1998](@cite).
 For example, the baryon number 3 tetrahedral skyrmion can be constructed as follows:
 
 ``` julia
@@ -56,10 +56,10 @@ The `make_rational_map!` function also accepts custom profile functions.
 
 ## ADHM data
 
-[ADHM skyrmions](https://arxiv.org/pdf/2110.15190) are skyrmions generated from ADHM data.
+[corkADHMSkyrmions2022](@cite) are skyrmions generated from ADHM data.
 The data consists of symmetric quaternionic matrices which satisfy a constraint.
 Most highly symmetric skyrmions can be represented by ADHM data.
-This package implements the very efficient [parallel transport](https://arxiv.org/abs/2204.04032) algorithm from Derek Harland.
+This package implements the very efficient [Harland2023](@citet) algorithm from Derek Harland.
 We can make the baryon number 2 toroidal skyrmion as follows:
 
 ``` julia

--- a/docs/src/making_skyrmions.md
+++ b/docs/src/making_skyrmions.md
@@ -1,6 +1,8 @@
 # Make, save and load Skyrmions
 
-Skyrmions in Skyrmions3D are represented by the `Skyrmion` struct. This contains all the information needed to reproduce the skyrmion: it's pion field, grid, pion mass etc. You can create a Skyrmion by passing some of these parameters, for example
+Skyrmions in Skyrmions3D are represented by the `Skyrmion` struct.
+This contains all the information needed to reproduce the skyrmion: it's pion field, grid, pion mass etc.
+You can create a Skyrmion by passing some of these parameters, for example
 
 ``` julia
  # A skyrmion on a 30^3 grid with lattice spacing 0.2
@@ -22,12 +24,14 @@ massive_periodic_skyrmion = Skyrmion(
 
 Find out more about the Skyrmion constructor in the API. 
 
-
-By default the pion field is set equal to `(0,0,0,1)`, which is that of a vacuum skyrmion. So we next want to add some field structure to it...
+By default the pion field is set equal to `(0,0,0,1)`, which is that of a vacuum skyrmion.
+So we next want to add some field structure to it...
 
 ## Rational Maps
 
-A complex rational map is defined by two complex valued polynomials; we call these the numerator `p(z)` and the denominator `q(z)`. Given these polynomials, we can create a skyrmion from the [rational map approximation](https://arxiv.org/pdf/hep-th/9705151). For example, the baryon number 3 tetrahedral skyrmion can be constructed as follows:
+A complex rational map is defined by two complex valued polynomials; we call these the numerator `p(z)` and the denominator `q(z)`.
+Given these polynomials, we can create a skyrmion from the [rational map approximation](https://arxiv.org/pdf/hep-th/9705151).
+For example, the baryon number 3 tetrahedral skyrmion can be constructed as follows:
 
 ``` julia
 p3(z) = sqrt(3)*im*z^2 - 1
@@ -35,9 +39,11 @@ q3(z) = z*(z^2 - sqrt(3)*im)
 make_rational_map!(my_skyrmion, p3, q3)
 ```
 
-Note: By convention the "bang" character `!` at the end of function means it is a _modifiying function_. So we are modifiying `my_skyrmion`, not creating a new skyrmion.
+Note: By convention the "bang" character `!` at the end of function means it is a _modifiying function_.
+So we are modifiying `my_skyrmion`, not creating a new skyrmion.
 
-The `make_rational_map!` function tries to estimate the degree of the rational map, and tries to find a reasonable profile function for it. If this all worked, you should get a sensible output when you compute the energy of the skyrmion.
+The `make_rational_map!` function tries to estimate the degree of the rational map, and tries to find a reasonable profile function for it.
+If this all worked, you should get a sensible output when you compute the energy of the skyrmion.
 
 ``` julia
 Energy(my_skyrmion)
@@ -50,7 +56,11 @@ The `make_rational_map!` function also accepts custom profile functions.
 
 ## ADHM data
 
-[ADHM skyrmions](https://arxiv.org/pdf/2110.15190) are skyrmions generated from ADHM data. The data consists of symmetric quaternionic matrices which satisfy a constraint. Most highly symmetric skyrmions can be represented by ADHM data. This package implements the very efficient [parallel transport](https://arxiv.org/abs/2204.04032) algorithm from Derek Harland. We can make the baryon number 2 toroidal skyrmion as follows:
+[ADHM skyrmions](https://arxiv.org/pdf/2110.15190) are skyrmions generated from ADHM data.
+The data consists of symmetric quaternionic matrices which satisfy a constraint.
+Most highly symmetric skyrmions can be represented by ADHM data.
+This package implements the very efficient [parallel transport](https://arxiv.org/abs/2204.04032) algorithm from Derek Harland.
+We can make the baryon number 2 toroidal skyrmion as follows:
 
 ``` julia
 using Quaternions
@@ -73,12 +83,11 @@ make_ADHM!(my_skyrmion, adhm_data)
 
 ## Save your Skyrmion
 
-Once you've created your skyrmion, you can save a copy of it in a folder. This folder will contain
-the pion fields in the [`HDF5` format](https://en.wikipedia.org/wiki/Hierarchical_Data_Format). These files
-can be read by all popular programming languages, and allows for excellent compression. In addition we
-save a human-readable `metadata.toml` file, containing the metadata associated with the Skyrmion, such as
-it's grid properties. Overall the folder structure is
-
+Once you've created your skyrmion, you can save a copy of it in a folder.
+This folder will contain the pion fields in the [`HDF5` format](https://en.wikipedia.org/wiki/Hierarchical_Data_Format).
+These files can be read by all popular programming languages, and allows for excellent compression.
+In addition we save a human-readable `metadata.toml` file, containing the metadata associated with the Skyrmion, such as it's grid properties.
+Overall the folder structure is
 ``` bash
 my_output_folder/
     pion_field.h5
@@ -86,16 +95,14 @@ my_output_folder/
 ```
 
 To save your skyrmion, simply run
-
 ``` julia
 save_skyrmion(my_skyrmion, path="path/to/my_output_folder")
 ```
 
-By default, this function will not overwrite existing folders. You can add additional metadata by passing
-a dictionary to the `additional_metadata` argument. Read more in the API.
-
+By default, this function will not overwrite existing folders.
+You can add additional metadata by passing a dictionary to the `additional_metadata` argument.
+Read more in the API.
 To load a save Skyrion, use the `load_skyrmion` function:
-
 ``` julia
 loaded_skyrmion = load_skyrmion("path/to/my_output_folder")
 ```

--- a/docs/src/properties.md
+++ b/docs/src/properties.md
@@ -1,6 +1,9 @@
 # Properties
 
-A skyrmion has many properties. In general, `Skyrmions3D` allows you to compute the integrand or integral of the property in question. For all the following examples, if you pass `density=true` you'll get the integrand. You can also get the `n`th moment by passing `moment=n`.
+A skyrmion has many properties.
+In general, `Skyrmions3D` allows you to compute the integrand or integral of the property in question.
+For all the following examples, if you pass `density=true` you'll get the integrand.
+You can also get the `n`th moment by passing `moment=n`.
 
 Suppose you have a ``B=4`` cubic skyrmion
 
@@ -48,11 +51,13 @@ Energy(skyrmion)
 >>> (6149.285364807477, "MeV")
 ```
 
-Note that the energy of the skyrmion is dependent both on its underlying pion field (which determines the energy density at a point) but also the grid, as the energy is calculated as the sum of the energy density over the grid. If the grid is not sufficiently large, the computed energy will be smaller than the 'true' value. 
+Note that the energy of the skyrmion is dependent both on its underlying pion field (which determines the energy density at a point) but also the grid, as the energy is calculated as the sum of the energy density over the grid.
+If the grid is not sufficiently large, the computed energy will be smaller than the 'true' value.
 
 ## Currents
 
-For currents, we use the function `compute_current` and pass a label. We list the currents and labels now:
+For currents, we use the function `compute_current` and pass a label.
+We list the currents and labels now:
 
 - Rotational moment of intertia, `vMOI`
 - Isorotational moment of intertia, `uMOI`
@@ -63,7 +68,8 @@ For currents, we use the function `compute_current` and pass a label. We list th
 - Noether-iso, `NoetherIso`
 - Noether-axial, `NoetherAxial`
 
-Like the `Energy` and `Baryon` we can get the densities by passing `density=true` and the `n`th moment by passing `moment=n`. For instance, the Isorotational moment of inertia of the cubic rational map skyrmion is
+Like the `Energy` and `Baryon` we can get the densities by passing `density=true` and the `n`th moment by passing `moment=n`.
+For instance, the Isorotational moment of inertia of the cubic rational map skyrmion is
 
 ```julia
 U = compute_current(skyrmion, label="uMOI")

--- a/docs/src/references.md
+++ b/docs/src/references.md
@@ -1,0 +1,4 @@
+# References
+
+```@bibliography
+```

--- a/docs/src/transform.md
+++ b/docs/src/transform.md
@@ -1,6 +1,7 @@
 # Transforming & Combining Skyrmions
 
-Once you have a skyrmion, there's a lot you can do with it. Suppose you've made a `B=2` torus like so
+Once you have a skyrmion, there's a lot you can do with it.
+Suppose you've made a `B=2` torus like so
 
 ```julia
 using Skyrmions3D
@@ -10,11 +11,13 @@ q(z) = 1
 make_rational_map!(toroidal_skyrmion, p, q)
 ```
 
-It's important here to remember that functions ending in `!` modify the skyrmion, while functions with no `!` will return a new skyrmion. With that in mind, you could now apply a...
+It's important here to remember that functions ending in `!` modify the skyrmion, while functions with no `!` will return a new skyrmion.
+With that in mind, you could now apply a...
 
 ## Translation
 
-Translations take in a skyrmion and a 3-vector. You can make a new skyrmion
+Translations take in a skyrmion and a 3-vector.
+You can make a new skyrmion
 
 ```julia
 X = [0.0,0.0,1.0]
@@ -28,7 +31,8 @@ or modify an existing skyrmion
 translate_sk!(toroidal_skyrmion, X=X)
 ```
 
-You can also "center" your skyrmion. This computes the center of mass, then translates so that the skyrmion has zero center of mass:
+You can also "center" your skyrmion.
+This computes the center of mass, then translates so that the skyrmion has zero center of mass:
 
 ``` julia
 # compute CoM for the translated skyrmion
@@ -50,7 +54,8 @@ center_of_mass(toroidal_skyrmion)
 
 ## Rotation
 
-Rotations take in a skyrmion, an angle and a rotation vector. You can make a new skyrmion
+Rotations take in a skyrmion, an angle and a rotation vector.
+You can make a new skyrmion
 
 ```julia
 rotated_skyrmion = rotate_sk(toroidal_skyrmion, theta=pi/4, n=[1.0,0.0,0.0])
@@ -66,7 +71,8 @@ rotate_sk!(toroidal_skyrmion, theta=theta, n=n)
 
 ## Isorotation
 
-Isorotations take in a skyrmion, an angle and a rotation vector. You can make a new skyrmion
+Isorotations take in a skyrmion, an angle and a rotation vector.
+You can make a new skyrmion
 
 ```julia
 isorotated_skyrmion = isorotate_sk(toroidal_skyrmion, theta=pi/4, n=[1.0,0.0,0.0])
@@ -82,7 +88,9 @@ isorotate_sk!(toroidal_skyrmion, theta=theta, n=n)
 
 ## Product Approximation
 
-We can also combine skyrmions using the Product Approximation. This codebase always applies a symmetrised product approx. Let's first create two tori
+We can also combine skyrmions using the Product Approximation.
+This codebase always applies a symmetrised product approx.
+Let's first create two tori
 
 ```julia
 p(z) = z^2

--- a/docs/src/visualisation.md
+++ b/docs/src/visualisation.md
@@ -11,7 +11,9 @@ p3(z) = sqrt(3)*im*z^2 - 1
 q3(z) = z*(z^2 - sqrt(3)*im)
 make_rational_map!(my_skyrmion, p3, q3)
 ```
-It would be nice to visualise this. Depending on your set-up, visualisation will work in different ways. On this page, we'll focus on static plots from the terminal.
+It would be nice to visualise this.
+Depending on your set-up, visualisation will work in different ways.
+On this page, we'll focus on static plots from the terminal.
 
 ## Plotting fields
 
@@ -21,7 +23,8 @@ We can plot the field with component `3` and isosurface with `iso_value=0.3` as 
 plot_field(my_skyrmion, iso_value=0.3, component=3)
 ```
 
-This might appear under your cell in Jupyter Notebook, pop-up in a seperate window, or something else. Hopefully whatever happens, you can see the following plot:
+This might appear under your cell in Jupyter Notebook, pop-up in a seperate window, or something else.
+Hopefully whatever happens, you can see the following plot:
 
 ```@raw html
 <img src="../../../src/images/visualisation/B3_field.png>
@@ -29,7 +32,8 @@ This might appear under your cell in Jupyter Notebook, pop-up in a seperate wind
 
 ## Saving figures
 
-The function `plot_field`, and all other plotting functions return a `Makie` `Figure`. We can save these
+The function `plot_field`, and all other plotting functions return a `Makie` `Figure`.
+We can save these
 
 ``` julia
 using Makie
@@ -47,7 +51,9 @@ plot_baryon_density(my_skyrmion)
 
 This function will automatically compute a reasonable iso_value, but you can insert your own if you'd like.
 
-I also implemented a fairly hideous juggling colouring. This can be useful to see symmetries. If you'd like to make this more attractive, please submit a PR!!
+I also implemented a fairly hideous juggling colouring.
+This can be useful to see symmetries.
+If you'd like to make this more attractive, please submit a PR!!
 
 ``` julia
 plot_baryon_density(my_skyrmion)

--- a/docs/src/visualisation.md
+++ b/docs/src/visualisation.md
@@ -27,7 +27,7 @@ This might appear under your cell in Jupyter Notebook, pop-up in a seperate wind
 Hopefully whatever happens, you can see the following plot:
 
 ```@raw html
-<img src="../../../src/images/visualisation/B3_field.png>
+<img src="../../../src/images/visualisation/B3_field.png">
 ```
 
 ## Saving figures

--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -171,3 +171,28 @@ author = {Gregory S. Adkins and Chiara R. Nappi and Edward Witten},
   doi = {10.1007/BF01238909},
 }
 
+@article{houghtonRationalMapsMonopoles1998,
+  title = {Rational Maps, Monopoles and Skyrmions},
+  author = {Houghton, Conor J. and Manton, Nicholas S. and Sutcliffe, Paul M.},
+  year = {1998},
+  month = jan,
+  journal = {Nuclear Physics B},
+  volume = {510},
+  number = {3},
+  pages = {507--537},
+  issn = {0550-3213},
+  doi = {10.1016/S0550-3213(97)00619-6},
+}
+
+@article{corkADHMSkyrmions2022,
+  title = {{{ADHM}} Skyrmions},
+  author = {Cork, Josh and Halcrow, Chris},
+  year = {2022},
+  month = aug,
+  journal = {Nonlinearity},
+  volume = {35},
+  number = {8},
+  pages = {3944--3990},
+  issn = {0951-7715, 1361-6544},
+  doi = {10.1088/1361-6544/ac72e6},
+}

--- a/src/Skyrmions3D.jl
+++ b/src/Skyrmions3D.jl
@@ -60,8 +60,11 @@ Create a vacuum skyrme field with `lp` lattice points and `ls` lattice spacing.
 - `vac = [0.0, 0.0, 0.0, 1.0]`: the value the vacuum pion field takes
 - `boundary_conditions = "dirichlet"`: the boundary conditions for the pion field
 
-The default values of `Fpi` and `ee` are taken to [roughly approximate experimental values](https://doi.org/10.1016/0550-3213(83)90559-X).
+The default values of `Fpi` and `ee` are taken to roughly approximate experimental values [Adkins1983](@cite).
 
+# References
+
+* [Adkins1983](@cite) Adkins et al. Nuclear Physics B 228, 552–566 (1983).
 """
 mutable struct Skyrmion
     pion_field::Array{Float64,4}
@@ -377,11 +380,15 @@ end
 """
     set_physical!(skyrmion, is_physical; Fpi = Fpi, ee = ee)
 
-Sets `skyrmion` to use physical units (as opposed to [Skyrme units](https://doi.org/10.1142/q0368)) when `is_physical` is `true`, and prints the physical units.
+Sets `skyrmion` to use physical units (as opposed to Skyrme units [Manton2022](@cite)) when `is_physical` is `true`, and prints the physical units.
 
 Also used to turn off physical units by setting `is_physical=false`.
 
-The physical energy unit is ``\\frac{F_\\pi}{4e}`` MeV and the physical length unit is ``\\frac{2\\hbar}{e F_\\pi}`` fm (where ``\\hbar \\approx 197.327`` MeV fm is the reduced Planck constant).  
+The physical energy unit is ``\\frac{F_\\pi}{4e}`` MeV and the physical length unit is ``\\frac{2\\hbar}{e F_\\pi}`` fm (where ``\\hbar \\approx 197.327`` MeV fm is the reduced Planck constant).
+
+# References
+
+* [Manton2022](@cite) Manton. _Skyrmions: a theory of nuclei_ (2022).
 
 """
 function set_physical!(skyrmion, physical; Fpi = skyrmion.Fpi, ee = skyrmion.ee)

--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -210,13 +210,17 @@ end
 """
     plot_baryon_density(skyrmion; iso_value = 0.25*(max(BD) + min(BD)), juggling = false, kwargs...)
     
-Plots an isosurface of constant baryon density, with value `iso_value` (where `BD` which determines the default value is the baryon density of `skyrmion` over its grid). The isosurface is coloured to reveal the pion field structure as originally described in [Classical Skyrmions -- static solutions and dynamics (Manton, 2012)](https://doi.org/10.1002/mma.2512).
+Plots an isosurface of constant baryon density, with value `iso_value` (where `BD` which determines the default value is the baryon density of `skyrmion` over its grid). The isosurface is coloured to reveal the pion field structure as originally described in [Manton2012](@cite).
 
 Can use a _juggling ball_ colouring scheme by setting `juggling = true`.
 
 # Optional argument
 
 Can accept any arguments used in `Axis3` from the `Makie` package.
+
+# References
+
+* [Manton2012](@cite) Manton. _Classical Skyrmions—static solutions and dynamics_ (2012).
 
 """
 function plot_baryon_density(skyrmion; juggling = false, iso_value = 0.0, kwargs...)

--- a/src/properties.jl
+++ b/src/properties.jl
@@ -59,11 +59,15 @@ Compute energy of `skyrmion`.
 
 Set 'density = true' to output the energy density and moment to `n` to calculate the `n`th moment of the energy density.
 
-If `skyrmion.physical` is false, then the returned value is the ``\\frac{1}{12\\pi^2}`` times the integral of the energy density, reflecting the [Fadeev bound on the energy of a 1-skyrmion](https://doi.org/10.1007/BF01238909) that ``E \\geq 12 \\pi^2``. Otherwise, the returned value is in the appropriate physical units, and including the factor of ``12 \\pi^2``. 
+If `skyrmion.physical` is false, then the returned value is the ``\\frac{1}{12\\pi^2}`` times the integral of the energy density, reflecting the Fadeev bound on the energy of a 1-skyrmion [Manton1987](@cite) that ``E \\geq 12 \\pi^2``. Otherwise, the returned value is in the appropriate physical units, and including the factor of ``12 \\pi^2``.
 
 Note that this method sums over the grid. If the grid is not sufficiently large, the computed energy will be smaller than the 'true' value. 
 
-See also [`get_energy_density!`](@ref). 
+See also [`get_energy_density!`](@ref).
+
+# References
+
+* [Manton1987](@cite) Manton. _Geometry of Skyrmions_ (1987).
 
 """
 function Energy(sk; density = false, moment = 0)


### PR DESCRIPTION
This PR adds [DocumenterCitations.jl](https://juliadocs.org/DocumenterCitations.jl/stable/) as a dependency and edits the documentation source (both the docstrings and the documentation pages) to make use of it, resolving #37.
It also reflows the documentation source to use one-sentence-per-line so as to make future documentation changes easier to handle in version control.

To see the changes made to the documentation post reflow, check commit b0c8fd6.